### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ DEMO: [Just Test It](https://github.com/artyomtrityak/just-test-it)
 
 Usage examples:
 
-###Basic
+### Basic
 
 ```js
 var Controller = Backbone.Controller.extend({
@@ -32,7 +32,7 @@ var Controller = Backbone.Controller.extend({
 var searchController = new Controller();
 ```
 
-###Controller supports default Backbone events
+### Controller supports default Backbone events
 
 ```js
 var Controller = Backbone.Controller.extend({
@@ -49,7 +49,7 @@ var Controller = Backbone.Controller.extend({
 var catsController = new Controller();
 ```
 
-###Controller has remove method for cleanup
+### Controller has remove method for cleanup
 
 Remove method should do correct remove for all controller views and models, stop listening controller events and clear state.
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
